### PR TITLE
ValueError Fix

### DIFF
--- a/indicator/indicators.py
+++ b/indicator/indicators.py
@@ -135,7 +135,8 @@ def EMA(df, base, target, period, alpha=False):
     
     if (alpha == True):
         # (1 - alpha) * previous_val + alpha * current_val where alpha = 1 / period
-        df[target] = con.ewm(alpha=1 / period, adjust=False).mean()
+        alpha= 1 / period
+        df[target] = con.ewm(alpha, adjust=False).mean()
     else:
         # ((current_val - previous_val) * coeff) + previous_val where coeff = 2 / (period + 1)
         df[target] = con.ewm(span=period, adjust=False).mean()


### PR DESCRIPTION
Fixing error in Python2.7

Traceback (most recent call last):
  File "test.py", line 24, in <module>
    SuperTrend(data, period=8, multiplier=3, ohlc=['open', 'high', 'low', 'close'])
  File "/opt/kit/pykite/ribbon/indicators.py", line 194, in SuperTrend
    ATR(df, period, ohlc=ohlc)
  File "/opt/kit/pykite/ribbon/indicators.py", line 173, in ATR
    EMA(df, 'TR', atr, period, alpha=True)
  File "/opt/kit/pykite/ribbon/indicators.py", line 138, in EMA
    df[target] = con.ewm(alpha=1 / period, adjust=False).mean()
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/generic.py", line 10166, in ewm
    adjust=adjust, ignore_na=ignore_na, axis=axis)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/window.py", line 2646, in ewm
    return EWM(obj, **kwds)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/window.py", line 2212, in __init__
    self.com = _get_center_of_mass(com, span, halflife, alpha)
  File "/usr/local/lib/python2.7/dist-packages/pandas/core/window.py", line 2555, in _get_center_of_mass
    raise ValueError("alpha must satisfy: 0 < alpha <= 1")
ValueError: alpha must satisfy: 0 < alpha <= 1
